### PR TITLE
Set viewport meta so styles are actually responsive on device

### DIFF
--- a/template/tmpl/layout.tmpl
+++ b/template/tmpl/layout.tmpl
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?js= title ?> - Documentation</title>
 
     <!--[if lt IE 9]>


### PR DESCRIPTION
### why am i doing this

All these responsive styles are very pretty but they don't actually work on devices (or simulated devices), it just renders the big site real tiny. This fixes that.
